### PR TITLE
Fixed FBSDK versions

### DIFF
--- a/GBHFacebookImagePicker.podspec
+++ b/GBHFacebookImagePicker.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
             'Images/*.{png}'
         ]
     }
-    s.dependency 'FBSDKCoreKit', '~> 4.33.0'
-    s.dependency 'FBSDKLoginKit', '~> 4.33.0'
+    s.dependency 'FBSDKCoreKit'
+    s.dependency 'FBSDKLoginKit'
 end


### PR DESCRIPTION
This commit fixes a issue, to include the newest FBSDK while including multiple version of FBSDK while using this library.

Please see attached image for fixed error message:

<img width="514" alt="screen shot 2018-06-08 at 19 54 10" src="https://user-images.githubusercontent.com/25478327/41173076-f9b56cfc-6b55-11e8-80bc-9d22da4d6ffd.png">